### PR TITLE
13 normalizing database and route names #34

### DIFF
--- a/app/controllers/api/v1/classes/barbarians_controller.rb
+++ b/app/controllers/api/v1/classes/barbarians_controller.rb
@@ -2,10 +2,10 @@ class API::V1::Classes::BarbariansController < ApplicationController
   respond_to :json
 
   def index
-    respond_with (Classes::Barbarian.all)
+    respond_with(Classes::Barbarian.all)
   end
 
   def show
-    respond_with (Classes::Barbarian.load_resource(params[:subclass], params[:level]))
+    respond_with(Classes::Barbarian.load_resource(params[:subclass], params[:level]))
   end
 end

--- a/app/controllers/api/v1/races_controller.rb
+++ b/app/controllers/api/v1/races_controller.rb
@@ -6,6 +6,6 @@ class API::V1::RacesController < ApplicationController
   end
 
   def show
-    respond_with(Race.find(params[:id]))
+    respond_with(Race.load_race(params[:race]))
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,7 +2,7 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def self.make_readable(string)
-    deslug(string).to_s
+    deslug(string).to_s unless string.nil?
   end
 
   def self.deslug(string)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,4 +8,12 @@ class ApplicationRecord < ActiveRecord::Base
   def self.deslug(string)
     string.downcase.tr('-', ' ')
   end
+
+  def self.number?(string)
+    true if Float(string) rescue false
+  end
+
+  def self.ci_find(attribute, value)
+    where("lower(#{attribute}) = ?", make_readable(value.downcase))
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,8 +12,4 @@ class ApplicationRecord < ActiveRecord::Base
   def self.number?(string)
     true if Float(string) rescue false
   end
-
-  def self.ci_find(attribute, value)
-    where("lower(#{attribute}) = ?", make_readable(value.downcase))
-  end
 end

--- a/app/models/classes.rb
+++ b/app/models/classes.rb
@@ -5,18 +5,14 @@ class Classes < ApplicationRecord
   def self.load_resource(subclass, level)
     if subclass && level
       if level.to_i > 2
-        find_by(subclass: subclass, level: level)
+        find_by(subclass: make_readable(subclass), level: level)
       else
         find_by(level: level)
       end
     elsif !number?(subclass) && level.nil?
-      where(subclass: subclass)
+      ci_find('subclass', make_readable(subclass))
     else
-      where(level: subclass)
+      ci_find('level', make_readable(subclass))
     end
-  end
-
-  def self.number?(string)
-    true if Float(string) rescue false
   end
 end

--- a/app/models/classes.rb
+++ b/app/models/classes.rb
@@ -5,14 +5,26 @@ class Classes < ApplicationRecord
   def self.load_resource(subclass, level)
     if subclass && level
       if level.to_i > 2
-        find_by(subclass: make_readable(subclass), level: level)
+        find_by_subclass_level(subclass, level)
       else
-        find_by(level: level)
+        find_by_level(level)
       end
     elsif !number?(subclass) && level.nil?
-      ci_find('subclass', make_readable(subclass))
+      find_by_subclass(subclass)
     else
-      ci_find('level', make_readable(subclass))
+      find_by_level(subclass)
     end
+  end
+
+  def self.find_by_level(level)
+    where('level = ?', level)
+  end
+
+  def self.find_by_subclass(subclass)
+    where('lower(subclass) = ?', make_readable(subclass.downcase))
+  end
+
+  def self.find_by_subclass_level(subclass, level)
+    where('lower(subclass) = ?', make_readable(subclass.downcase)).where('level = ?', level)
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -5,4 +5,17 @@ class Race < ApplicationRecord
   has_many :traits, through: :joins_trait
   has_many :joins_skill
   has_many :skills, through: :joins_skill
+
+  def self.load_race(name)
+    if !number?(name)
+      find_by_race(name)
+    else
+      find(name)
+    end
+  end
+
+  def self.find_by_race(name)
+    where('lower(name) = ? OR lower(subrace) = ?',
+          make_readable(name.downcase), make_readable(name.downcase))
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,53 +12,53 @@ Rails.application.routes.draw do
 
       # Classes
       namespace :classes do
-        get 'barbarians/:subclass/:level', to: 'barbarians#show'
-        get 'barbarians/:subclass', to: 'barbarians#show'
-        get 'barbarians', to: 'barbarians#index'
+        get 'barbarian/:subclass/:level', to: 'barbarians#show'
+        get 'barbarian/:subclass', to: 'barbarians#show'
+        get 'barbarian', to: 'barbarians#index'
 
-        get 'bards/:subclass/:level', to: 'bards#show'
-        get 'bards/:subclass', to: 'bards#show'
-        resources :bards
+        get 'bard/:subclass/:level', to: 'bards#show'
+        get 'bard/:subclass', to: 'bards#show'
+        get 'bard', to: 'bards#index'
 
-        get 'clerics/:subclass/:level', to: 'clerics#show'
-        get 'clerics/:subclass', to: 'clerics#show'
-        resources :clerics
+        get 'cleric/:subclass/:level', to: 'clerics#show'
+        get 'cleric/:subclass', to: 'clerics#show'
+        get 'cleric', to: 'clerics#index'
 
-        get 'druids/:subclass/:level', to: 'druids#show'
-        get 'druids/:subclass', to: 'druids#show'
-        resources :druids
+        get 'druid/:subclass/:level', to: 'druids#show'
+        get 'druid/:subclass', to: 'druids#show'
+        get 'druid', to: 'druids#index'
 
-        get 'fighters/:subclass/:level', to: 'fighters#show'
-        get 'fighters/:subclass', to: 'fighters#show'
-        resources :fighters
+        get 'fighter/:subclass/:level', to: 'fighters#show'
+        get 'fighter/:subclass', to: 'fighters#show'
+        get 'fighter', to: 'fighters#index'
 
-        get 'monks/:subclass/:level', to: 'monks#show'
-        get 'monks/:subclass', to: 'monks#show'
-        resources :monks
+        get 'monk/:subclass/:level', to: 'monks#show'
+        get 'monk/:subclass', to: 'monks#show'
+        get 'monk', to: 'monks#index'
 
-        get 'paladins/:subclass/:level', to: 'paladins#show'
-        get 'paladins/:subclass', to: 'paladins#show'
-        resources :paladins
+        get 'paladin/:subclass/:level', to: 'paladins#show'
+        get 'paladin/:subclass', to: 'paladins#show'
+        get 'paladin', to: 'paladins#index'
 
-        get 'rangers/:subclass/:level', to: 'rangers#show'
-        get 'rangers/:subclass', to: 'rangers#show'
-        resources :rangers
+        get 'ranger/:subclass/:level', to: 'rangers#show'
+        get 'ranger/:subclass', to: 'rangers#show'
+        get 'ranger', to: 'rangers#index'
 
-        get 'rogues/:subclass/:level', to: 'rogues#show'
-        get 'rogues/:subclass', to: 'rogues#show'
-        resources :rogues
+        get 'rogue/:subclass/:level', to: 'rogues#show'
+        get 'rogue/:subclass', to: 'rogues#show'
+        get 'rogue', to: 'rogues#index'
 
-        get 'sorcerers/:subclass/:level', to: 'sorcerers#show'
-        get 'sorcerers/:subclass', to: 'sorcerers#show'
-        resources :sorcerers
+        get 'sorcerer/:subclass/:level', to: 'sorcerers#show'
+        get 'sorcerer/:subclass', to: 'sorcerers#show'
+        get 'sorcerer', to: 'sorcerers#index'
 
-        get 'warlocks/:subclass/:level', to: 'warlocks#show'
-        get 'warlocks/:subclass', to: 'warlocks#show'
-        resources :warlocks
+        get 'warlock/:subclass/:level', to: 'warlocks#show'
+        get 'warlock/:subclass', to: 'warlocks#show'
+        get 'warlock', to: 'warlocks#index'
 
-        get 'wizards/:subclass/:level', to: 'wizards#show'
-        get 'wizards/:subclass', to: 'wizards#show'
-        resources :wizards
+        get 'wizard/:subclass/:level', to: 'wizards#show'
+        get 'wizard/:subclass', to: 'wizards#show'
+        get 'wizard', to: 'wizards#index'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
         get ':race/:class/:subclass/:level', to: 'characters#show'
       end
 
-      resources :races
+      get 'races/:race', to: 'races#show'
+      get 'races', to: 'races#index'
 
       # Classes
       namespace :classes do


### PR DESCRIPTION
closes #33 and closes #34 - we now have finder methods that will not be bothered by case and can read friendly urls like 'totem-warrior' or 'high-elf'

this has only been implemented for our races and classes at this time, further additions will come as we add more models and routes