### PR TITLE
14 add routing options for race/subrace #46

### DIFF
--- a/app/controllers/api/v1/races_controller.rb
+++ b/app/controllers/api/v1/races_controller.rb
@@ -6,6 +6,6 @@ class API::V1::RacesController < ApplicationController
   end
 
   def show
-    respond_with(Race.load_race(params[:race]))
+    respond_with(Race.load_race(params[:race], params[:subrace]))
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -6,16 +6,22 @@ class Race < ApplicationRecord
   has_many :joins_skill
   has_many :skills, through: :joins_skill
 
-  def self.load_race(name)
-    if !number?(name)
-      find_by_race(name)
+  def self.load_race(race, subrace)
+    if !number?(race) && !subrace.nil?
+      find_by_subrace(race, subrace)
+    elsif !number?(race) && subrace.nil?
+      find_by_race(race)
     else
-      find(name)
+      where(id: race)
     end
   end
 
-  def self.find_by_race(name)
-    find_by('lower(name) = ? OR lower(subrace) = ?',
-            make_readable(name.downcase), make_readable(name.downcase))
+  def self.find_by_race(race)
+    where('lower(name) = ?', make_readable(race.downcase))
+  end
+
+  def self.find_by_subrace(race, subrace)
+    find_by('lower(name) = ? AND lower(subrace) = ?',
+            make_readable(race.downcase), make_readable(subrace.downcase))
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         get ':race/:class/:subclass/:level', to: 'characters#show'
       end
 
+      get 'races/:race/:subrace', to: 'races#show'
       get 'races/:race', to: 'races#show'
       get 'races', to: 'races#index'
 

--- a/db/seeds/joins_languages.rb
+++ b/db/seeds/joins_languages.rb
@@ -78,17 +78,17 @@ JoinsLanguage.create(
 # == DROW ======================================================================
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Dark Elf (Drow)').id,
+  race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Dark Elf (Drow)').id,
+  race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Dark Elf (Drow)').id,
+  race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Undercommon').id
 )
 
@@ -143,17 +143,17 @@ JoinsLanguage.create(
 # == DEEP GNOME ================================================================
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Gnomish').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Undercommon').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
@@ -205,24 +205,24 @@ JoinsLanguage.create(
 # == HALF-ELF ==================================================================
 
 JoinsLanguage.create(
-  race_id: Race.find_by(name: 'Half-Elf').id,
+  race_id: Race.find_by(name: 'Half Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(name: 'Half-Elf').id,
+  race_id: Race.find_by(name: 'Half Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
 # == HALF-ORC ==================================================================
 
 JoinsLanguage.create(
-  race_id: Race.find_by(name: 'Half-Orc').id,
+  race_id: Race.find_by(name: 'Half Orc').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 JoinsLanguage.create(
-  race_id: Race.find_by(name: 'Half-Orc').id,
+  race_id: Race.find_by(name: 'Half Orc').id,
   language_id: Language.find_by(name: 'Goblin').id
 )
 

--- a/db/seeds/joins_traits.rb
+++ b/db/seeds/joins_traits.rb
@@ -74,17 +74,17 @@ JoinsTrait.create(
 # == DEEP GNOME ================================================================
 
 JoinsTrait.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Superior Darkvision').id
 )
 
 JoinsTrait.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Gnome Cunning').id
 )
 
 JoinsTrait.create(
-  race_id: Race.find_by(subrace: 'Deep Gnome (Svirfneblin)').id,
+  race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Stone Camouflage').id
 )
 
@@ -129,7 +129,7 @@ JoinsTrait.create(
 # == HALF-ELF ==================================================================
 
 JoinsTrait.create(
-  race_id: Race.find_by(name: 'Half-Elf').id,
+  race_id: Race.find_by(name: 'Half Elf').id,
   trait_id: Trait.find_by(race_name: 'Extra Language of Choice').id
 )
 

--- a/db/seeds/races.rb
+++ b/db/seeds/races.rb
@@ -145,7 +145,7 @@ Race.create(
 
 Race.create(
   name: 'Elf',
-  subrace: 'Dark Elf (Drow)',
+  subrace: 'Dark Elf',
   desc: 'Description goes here',
   speed: 30,
   darkvision: 120,
@@ -257,7 +257,7 @@ Race.create(
 # == DEEP GNOME ===========================
 Race.create(
   name: 'Gnome',
-  subrace: 'Deep Gnome (Svirfneblin)',
+  subrace: 'Deep Gnome',
   desc: 'Forest gnomes and rock gnomes are the gnomes most commonly encountered in the lands of the surface world. There is another subrace of gnomes rarely seen by any surface-dweller: deep gnomes, also known as svirfneblin. Guarded, and suspicious of outsiders, svirfneblin are cunning and taciturn, but can be just as kind-hearted, loyal, and compassionate as their surface cousins.\n\rBorn of Deep Earth: Svirfneblin seem more like creatures of stone than flesh. Their leathery skin is usually a gray, brown, or dun hue that acts as a natural camouflage with the rock around them. Their bodies are gnarled with hard muscle or fat, and they are heavier than their small stature suggests; svirfneblin often weigh 100 pounds or more but rarely stand much more than 3 feet tall. Male svirfneblin are bald from early childhood, although adults can grow stiff beards or mustaches. Females have full heads of hair, and they usually tie their hair back in braids or cut it short to keep it from getting in their way as they work. Svirfneblin are well adapted for their subterranean existence. They have excellent darkvision, and many of them have magical talents that rival the innate spellcasting of the drow and duergar. They are surprisingly strong for their size, enduring toil and danger that would overwhelm most other people.\n\rMaster Miners: Despite their guarded natures, svirfneblin aren’t joyless. They admire skillful work and delicate craftsmanship, just like any other gnome. Svirfneblin love gemstones of all kinds, and they boldly seek out precious stones in the deepest and darkest tunnels. They are also expert gemcutters and miners, and they prize rubies above all other gemstones.\n\rDeep Dwellers: Svirfneblin are known as deep gnomes because they choose to live far below the earth’s surface. Most svirfneblin never see the light of day. Their homes are well-hidden strongholds concealed by mazelike passages and clever illusions. Vast networks of mine tunnels ring most svirfneblin settlements, guarded by deadly traps and concealed sentries. Once a traveler passes through the outer defenses, the tunnels open up into marvelous cavern-towns carved from the surrounding rock with exquisite care. The svirfneblin are austere in their comforts compared to their surface cousins, but they take great pride in their stonework. Deep gnomes do their best to remain hidden. Even if surface travelers succeed in locating a svirfneblin community, winning their trust can be even more difficult. Those rare travelers who do succeed in befriending deep gnomes find that they are loyal and courageous allies against any foe. \n\rScouts and Spies: Surface-dwelling gnomes often take up the adventurer’s life out of sheer curiosity about the world around them, eager to see new things and meet new people. By comparison, most svirfneblin possess very little wanderlust and rarely travel far from home. They see the surface world as a bewildering place without boundaries and filled with unknown dangers. Nevertheless, a few svirfneblin understand that it is necessary to know something about what is happening on the surface near their hidden refuges. As a result, some svirfneblin become scouts, spies, or messengers who venture abroad, doing their best to avoid attention. These travelers are notoriously close-mouthed about where they come from and what they are up to, but a few eventually learn to trust good-hearted people of the surface world. A few svirfneblin become merchants who deal with other races both above and below ground. Drow, duergar, and other peoples know that svirfneblin are usually neutral in outlook and typically honest in their dealings. Serving as middlemen between races too hostile to deal with each other directly can be lucrative, and it serves an important defensive function; svirfneblin middlemen tend to know more about rumors and threats between rival merchants than anybody else.',
   speed: 25,
   darkvision: 120,
@@ -399,7 +399,7 @@ Race.create(
 # == HALF-ELF =============================
 
 Race.create(
-  name: 'Half-Elf',
+  name: 'Half Elf',
   desc: 'Description Goes Here',
   speed: 30,
   ability_bonuses: '0,1,0,2,0,0',
@@ -422,7 +422,7 @@ Race.create(
 # == HALF-ORC =============================
 
 Race.create(
-  name: 'Half-Orc',
+  name: 'Half Orc',
   desc: 'Description Goes Here',
   speed: 30,
   ability_bonuses: '0,1,0,2,0,0',

--- a/db/seeds/traits.rb
+++ b/db/seeds/traits.rb
@@ -25,7 +25,7 @@ Trait.create(
 
 Trait.create(
   race_name: 'Superior Darkvision',
-  description: 'Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray',
+  description: 'Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 120 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray',
   range: '120'
 )
 

--- a/spec/requests/races_spec.rb
+++ b/spec/requests/races_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe 'Races', type: :request do
   describe 'GET /v1/races/:id' do
     it 'returns the correct object when searching by id' do
       load_races
-      get '/v1/races/14'
+      get '/v1/races/10'
 
       expect(response.status).to eq(200)
-      expect(parsed_response['name']).to eq('Human')
+      expect(parsed_response.first['name']).to eq('Human')
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe 'Races', type: :request do
       get '/v1/races/dragonborn'
 
       expect(response.status).to eq(200)
-      expect(parsed_response['name']).to eq('Dragonborn')
+      expect(parsed_response.first['name']).to eq('Dragonborn')
     end
 
     it 'returns an array of subraces if they exist' do
@@ -58,26 +58,19 @@ RSpec.describe 'Races', type: :request do
   end
 
   describe 'GET /v1/races/:race/:subrace' do
-    it 'returns the correct object with a 200 response' do
+    it 'returns the correct object when using friendly urls' do
+      load_races
       get '/v1/races/elf/high-elf'
       expect(response.status).to eq(200)
       expect(parsed_response['name']).to eq('Elf')
       expect(parsed_response['subrace']).to eq('High Elf')
     end
 
-    it 'returns the correct object if no subrace is needed' do
+    it 'does not return any results with invalid data' do
       load_races
-      get '/v1/races/dragonborn'
+      get '/v1/races/dark-elf'
       expect(response.status).to eq(200)
-      expect(parsed_response['name']).to eq('Dragonborn')
-    end
-
-    it 'returns the correct object when using friendly urls' do
-      load_races
-      get '/v1/races/high-elf'
-      expect(response.status).to eq(200)
-      expect(parsed_response['name']).to eq('Elf')
-      expect(parsed_response['subrace']).to eq('High Elf')
+      expect(parsed_response).to eq([])
     end
   end
 end


### PR DESCRIPTION
closes #46 - added new routes for our races, /v1/races/elf will give us an array of elf subraces available, however /v1/races/human gives us an array with just one entry, this was intentional to keep our resources standardized across the board.  /v1/races/elf/dark-elf will give us a single race entry.

Maybe we should look into adding subraces for the entries that don't actually have any and make it the same as the normal race name, possible change for the future