### PR TITLE
Rename joins tables to be more descriptive #74

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,6 +1,6 @@
 class Language < ApplicationRecord
-  has_many :joins_language
-  has_many :races, through: :joins_language
+  has_many :racial_languages
+  has_many :races, through: :racial_languages
 
   def self.load_language(name)
     if !number?(name)

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -3,8 +3,8 @@ class Race < ApplicationRecord
   has_many :languages, through: :racial_languages
   has_many :joins_trait
   has_many :traits, through: :joins_trait
-  has_many :joins_skill
-  has_many :skills, through: :joins_skill
+  has_many :racial_skills
+  has_many :skills, through: :racial_skills
   has_many :racial_ability_bonuses
   has_many :abilities, through: :racial_ability_bonuses
 

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,6 +1,6 @@
 class Race < ApplicationRecord
-  has_many :joins_language
-  has_many :languages, through: :joins_language
+  has_many :racial_languages
+  has_many :languages, through: :racial_languages
   has_many :joins_trait
   has_many :traits, through: :joins_trait
   has_many :joins_skill

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,8 +1,8 @@
 class Race < ApplicationRecord
   has_many :racial_languages
   has_many :languages, through: :racial_languages
-  has_many :joins_trait
-  has_many :traits, through: :joins_trait
+  has_many :racial_traits
+  has_many :traits, through: :racial_traits
   has_many :racial_skills
   has_many :skills, through: :racial_skills
   has_many :racial_ability_bonuses

--- a/app/models/racial_language.rb
+++ b/app/models/racial_language.rb
@@ -1,4 +1,4 @@
-class JoinsLanguage < ApplicationRecord
+class RacialLanguage < ApplicationRecord
   belongs_to :race
   belongs_to :language
 end

--- a/app/models/racial_skill.rb
+++ b/app/models/racial_skill.rb
@@ -1,4 +1,4 @@
-class JoinsSkill < ApplicationRecord
+class RacialSkill < ApplicationRecord
   belongs_to :race
   belongs_to :skill
 end

--- a/app/models/racial_trait.rb
+++ b/app/models/racial_trait.rb
@@ -1,4 +1,4 @@
-class JoinsTrait < ApplicationRecord
+class RacialTrait < ApplicationRecord
   belongs_to :race
   belongs_to :trait
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,7 +1,7 @@
 class Skill < ApplicationRecord
   belongs_to :ability
-  has_one :joins_skill
-  has_one :race, through: :joins_skill
+  has_one :racial_skill
+  has_one :race, through: :racial_skill
 
   def self.load_skill(skill)
     find_by('lower(name) = ?', make_readable(skill))

--- a/app/models/trait.rb
+++ b/app/models/trait.rb
@@ -1,6 +1,6 @@
 class Trait < ApplicationRecord
-  has_many :joins_traits
-  has_many :races, through: :joins_traits
+  has_many :racial_traits
+  has_many :races, through: :racial_traits
 
   def self.load_trait(trait)
     find_by('lower(race_name) = ?', make_readable(trait))

--- a/db/migrate/20160912010142_create_racial_languages.rb
+++ b/db/migrate/20160912010142_create_racial_languages.rb
@@ -1,6 +1,6 @@
-class CreateJoinsLanguages < ActiveRecord::Migration[5.0]
+class CreateRacialLanguages < ActiveRecord::Migration[5.0]
   def change
-    create_table :joins_languages do |t|
+    create_table :racial_languages do |t|
       t.integer :race_id
       t.integer :class_id
       t.integer :background_id

--- a/db/migrate/20160912010150_create_racial_traits.rb
+++ b/db/migrate/20160912010150_create_racial_traits.rb
@@ -1,6 +1,6 @@
-class CreateJoinsTraits < ActiveRecord::Migration[5.0]
+class CreateRacialTraits < ActiveRecord::Migration[5.0]
   def change
-    create_table :joins_traits do |t|
+    create_table :racial_traits do |t|
       t.integer :race_id, null: false
       t.integer :trait_id, null: false
     end

--- a/db/migrate/20160912010151_create_joins_equipment.rb
+++ b/db/migrate/20160912010151_create_joins_equipment.rb
@@ -1,8 +1,0 @@
-class CreateJoinsEquipment < ActiveRecord::Migration[5.0]
-  def change
-    create_table :joins_equipment do |t|
-      t.integer :race_id, null: false
-      t.integer :equipment_id, null: false
-    end
-  end
-end

--- a/db/migrate/20161114025652_create_racial_skills.rb
+++ b/db/migrate/20161114025652_create_racial_skills.rb
@@ -1,6 +1,6 @@
-class CreateJoinsSkills < ActiveRecord::Migration[5.0]
+class CreateRacialSkills < ActiveRecord::Migration[5.0]
   def change
-    create_table :joins_skills do |t|
+    create_table :racial_skills do |t|
       t.integer :race_id, null: false
       t.integer :skill_id, null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,11 +64,6 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.integer "equipment_id", null: false
   end
 
-  create_table "joins_traits", force: :cascade do |t|
-    t.integer "race_id",  null: false
-    t.integer "trait_id", null: false
-  end
-
   create_table "languages", force: :cascade do |t|
     t.string "name",                      null: false
     t.string "script", default: "Common"
@@ -139,6 +134,11 @@ ActiveRecord::Schema.define(version: 20170108034325) do
   create_table "racial_skills", force: :cascade do |t|
     t.integer "race_id",  null: false
     t.integer "skill_id", null: false
+  end
+
+  create_table "racial_traits", force: :cascade do |t|
+    t.integer "race_id",  null: false
+    t.integer "trait_id", null: false
   end
 
   create_table "skills", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,11 +64,6 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.integer "equipment_id", null: false
   end
 
-  create_table "joins_skills", force: :cascade do |t|
-    t.integer "race_id",  null: false
-    t.integer "skill_id", null: false
-  end
-
   create_table "joins_traits", force: :cascade do |t|
     t.integer "race_id",  null: false
     t.integer "trait_id", null: false
@@ -139,6 +134,11 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.integer "trait_id"
     t.integer "feat_id"
     t.integer "language_id",   null: false
+  end
+
+  create_table "racial_skills", force: :cascade do |t|
+    t.integer "race_id",  null: false
+    t.integer "skill_id", null: false
   end
 
   create_table "skills", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,11 +59,6 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.string "bonuses"
   end
 
-  create_table "joins_equipment", force: :cascade do |t|
-    t.integer "race_id",      null: false
-    t.integer "equipment_id", null: false
-  end
-
   create_table "languages", force: :cascade do |t|
     t.string "name",                      null: false
     t.string "script", default: "Common"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,15 +64,6 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.integer "equipment_id", null: false
   end
 
-  create_table "joins_languages", force: :cascade do |t|
-    t.integer "race_id"
-    t.integer "class_id"
-    t.integer "background_id"
-    t.integer "trait_id"
-    t.integer "feat_id"
-    t.integer "language_id",   null: false
-  end
-
   create_table "joins_skills", force: :cascade do |t|
     t.integer "race_id",  null: false
     t.integer "skill_id", null: false
@@ -139,6 +130,15 @@ ActiveRecord::Schema.define(version: 20170108034325) do
     t.integer "race_id",    null: false
     t.integer "ability_id", null: false
     t.integer "bonus",      null: false
+  end
+
+  create_table "racial_languages", force: :cascade do |t|
+    t.integer "race_id"
+    t.integer "class_id"
+    t.integer "background_id"
+    t.integer "trait_id"
+    t.integer "feat_id"
+    t.integer "language_id",   null: false
   end
 
   create_table "skills", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,9 @@
 # ==============================================================================
 
 seed_files = %w(abilities skills traits languages races racial_ability_bonuses
-                joins_traits racial_languages class_names subclasses
-                class_primary_abilities class_saving_throws class_skills)
+                racial_traits racial_languages racial_skills class_names
+                subclasses class_primary_abilities class_saving_throws
+                class_skills)
 
 seed_files.each do |part|
   require File.expand_path(File.dirname(__FILE__)) + "/seeds/#{part}.rb"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,7 @@
 # ==============================================================================
 
 seed_files = %w(abilities skills traits languages races racial_ability_bonuses
-                joins_traits joins_languages class_names subclasses
+                joins_traits racial_languages class_names subclasses
                 class_primary_abilities class_saving_throws class_skills)
 
 seed_files.each do |part|

--- a/db/seeds/racial_languages.rb
+++ b/db/seeds/racial_languages.rb
@@ -1,246 +1,246 @@
 # == DRAGONBORN ================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Dragonborn').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Dragonborn').id,
   language_id: Language.find_by(name: 'Draconic').id
 )
 
 # == MOUNTAIN DWARF ============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Mountain Dwarf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Mountain Dwarf').id,
   language_id: Language.find_by(name: 'Dwarvish').id
 )
 
 # == HILL DWARF ================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Hill Dwarf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Hill Dwarf').id,
   language_id: Language.find_by(name: 'Dwarvish').id
 )
 
 # == DUERGAR ===================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Duergar').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Duergar').id,
   language_id: Language.find_by(name: 'Dwarvish').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Duergar').id,
   language_id: Language.find_by(name: 'Undercommon').id
 )
 
 # == HIGH ELF ==================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
 # == WOOD ELF ==================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
 # == DROW ======================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   language_id: Language.find_by(name: 'Undercommon').id
 )
 
 # == AIR GENSAI ===============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Air Gensai').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Air Gensai').id,
   language_id: Language.find_by(name: 'Primordial').id
 )
 
 # == EARTH GENSAI ==============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Earth Gensai').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Earth Gensai').id,
   language_id: Language.find_by(name: 'Primordial').id
 )
 
 # == FIRE GENSAI ===============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Fire Gensai').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Fire Gensai').id,
   language_id: Language.find_by(name: 'Primordial').id
 )
 
 # == WATER GENSAI ==============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Water Gensai').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Water Gensai').id,
   language_id: Language.find_by(name: 'Primordial').id
 )
 
 # == DEEP GNOME ================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Gnomish').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Undercommon').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 # == ROCK GNOME ================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   language_id: Language.find_by(name: 'Gnomish').id
 )
 
 # == GOLIATH ===================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Goliath').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Goliath').id,
   language_id: Language.find_by(name: 'Giant').id
 )
 
 # == LIGHTFOOT HALFLING ========================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Lightfoot Halfling').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 # == STOUT HALFLING=============================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Stout Halfling').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 # == GHOSTWISE HALFLING=========================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(subrace: 'Ghostwise Halfling').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 # == HALF-ELF ==================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Half Elf').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Half Elf').id,
   language_id: Language.find_by(name: 'Elvish').id
 )
 
 # == HALF-ORC ==================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Half Orc').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Half Orc').id,
   language_id: Language.find_by(name: 'Goblin').id
 )
 
 # == HUMAN =====================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Human').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
 # == TIEFLING ==================================================================
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Tiefling').id,
   language_id: Language.find_by(name: 'Common').id
 )
 
-JoinsLanguage.create(
+RacialLanguage.create(
   race_id: Race.find_by(name: 'Tiefling').id,
   language_id: Language.find_by(name: 'Infernal').id
 )

--- a/db/seeds/racial_skills.rb
+++ b/db/seeds/racial_skills.rb
@@ -16,21 +16,21 @@
 
 # == HIGH ELF ==================================================================
 
-JoinsSkill.create(
+RacialSkill.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   skill_id: Skill.find_by(name: 'Perception').id
 )
 
 # == WOOD ELF ==================================================================
 
-JoinsSkill.create(
+RacialSkill.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   skill_id: Skill.find_by(name: 'Perception').id
 )
 
 # == DROW ======================================================================
 
-JoinsSkill.create(
+RacialSkill.create(
   race_id: Race.find_by(subrace: 'Dark Elf (Drow)').id,
   skill_id: Skill.find_by(name: 'Perception').id
 )
@@ -49,7 +49,7 @@ JoinsSkill.create(
 
 # == GOLIATH ===================================================================
 
-JoinsSkill.create(
+RacialSkill.create(
   race_id: Race.find_by(name: 'Goliath').id,
   skill_id: Skill.find_by(name: 'Athletics').id
 )

--- a/db/seeds/racial_skills.rb
+++ b/db/seeds/racial_skills.rb
@@ -31,7 +31,7 @@ RacialSkill.create(
 # == DROW ======================================================================
 
 RacialSkill.create(
-  race_id: Race.find_by(subrace: 'Dark Elf (Drow)').id,
+  race_id: Race.find_by(subrace: 'Dark Elf').id,
   skill_id: Skill.find_by(name: 'Perception').id
 )
 

--- a/db/seeds/racial_traits.rb
+++ b/db/seeds/racial_traits.rb
@@ -1,16 +1,16 @@
 # == DRAGONBORN ================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(name: 'Dragonborn').id,
   trait_id: Trait.find_by(race_name: 'Breath Weapon').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(name: 'Dragonborn').id,
   trait_id: Trait.find_by(race_name: 'Draconic Ancestry').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(name: 'Dragonborn').id,
   trait_id: Trait.find_by(race_name: 'Draconic Resistance').id
 )
@@ -29,106 +29,106 @@ JoinsTrait.create(
 
 # == HIGH ELF ==================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Elvish Darkvision').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Keen Senses').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Trance').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Fae Ancestry').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Elven Weapon Training').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'High Elf').id,
   trait_id: Trait.find_by(race_name: 'Extra Language of Choice').id
 )
 
 # == WOOD ELF ==================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Elvish Darkvision').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Keen Senses').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Trance').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Fae Ancestry').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Elven Weapon Training').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Fleet of Foot').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Wood Elf').id,
   trait_id: Trait.find_by(race_name: 'Mask of the Wild').id
 )
 
 # == DARK ELF ==================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Superior Darkvision').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Keen Senses').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Trance').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Fae Ancestry').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Sunlight Sensitivity').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Drow Magic').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Dark Elf').id,
   trait_id: Trait.find_by(race_name: 'Drow Weapon Training').id
 )
@@ -139,39 +139,39 @@ JoinsTrait.create(
 
 # == DEEP GNOME ================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Superior Darkvision').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Gnome Cunning').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Deep Gnome').id,
   trait_id: Trait.find_by(race_name: 'Stone Camouflage').id
 )
 
 # == ROCK GNOME ================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   trait_id: Trait.find_by(race_name: 'Gnomish Darkvision').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   trait_id: Trait.find_by(race_name: 'Gnome Cunning').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   trait_id: Trait.find_by(race_name: 'Artificiers Lore').id
 )
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(subrace: 'Rock Gnome').id,
   trait_id: Trait.find_by(race_name: 'Tinker').id
 )
@@ -194,7 +194,7 @@ JoinsTrait.create(
 
 # == HALF-ELF ==================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(name: 'Half Elf').id,
   trait_id: Trait.find_by(race_name: 'Extra Language of Choice').id
 )
@@ -205,7 +205,7 @@ JoinsTrait.create(
 
 # == HUMAN =====================================================================
 
-JoinsTrait.create(
+RacialTrait.create(
   race_id: Race.find_by(name: 'Human').id,
   trait_id: Trait.find_by(race_name: 'Extra Language of Choice').id
 )


### PR DESCRIPTION
closes #74 

changed the name of several database tables to fit our newer naming scheme.  this scheme is a bit more descriptive as to what each table is there for and which tables it joins together without the needs for 'join' in every table.